### PR TITLE
NSNumberFormatterCurrencyStyle has no fraction digits in iOS 7

### DIFF
--- a/FormattedCurrencyInput/ViewController.m
+++ b/FormattedCurrencyInput/ViewController.m
@@ -70,7 +70,7 @@
 
 - (BOOL)textField:(UITextField*)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString*)string
 {
-    int MAX_DIGITS = 11; // $999,999,999.99
+    NSInteger MAX_DIGITS = 11; // $999,999,999.99
     
     NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
     [numberFormatter setNumberStyle:NSNumberFormatterCurrencyStyle];
@@ -130,8 +130,8 @@
         
         if (cursorOffset != textFieldTextStrLength)
         {
-            int lengthDelta = textFieldTextNewStr.length - textFieldTextStrLength;
-            int newCursorOffset = MAX(0, MIN(textFieldTextNewStr.length, cursorOffset + lengthDelta));
+            NSInteger lengthDelta = textFieldTextNewStr.length - textFieldTextStrLength;
+            NSInteger newCursorOffset = MAX(0, MIN(textFieldTextNewStr.length, cursorOffset + lengthDelta));
             UITextPosition* newPosition = [textField positionFromPosition:textField.beginningOfDocument offset:newCursorOffset];
             UITextRange* newRange = [textField textRangeFromPosition:newPosition toPosition:newPosition];
             [textField setSelectedTextRange:newRange];

--- a/FormattedCurrencyInput/ViewController.m
+++ b/FormattedCurrencyInput/ViewController.m
@@ -23,6 +23,9 @@
     
     NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
     [numberFormatter setNumberStyle:NSNumberFormatterCurrencyStyle];
+    [numberFormatter setMaximumFractionDigits:2];
+    [numberFormatter setMinimumFractionDigits:2];
+    
     _textField.text = [numberFormatter stringFromNumber:[NSNumber numberWithInt:0]];
 }
 
@@ -71,6 +74,8 @@
     
     NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
     [numberFormatter setNumberStyle:NSNumberFormatterCurrencyStyle];
+    [numberFormatter setMaximumFractionDigits:2];
+    [numberFormatter setMinimumFractionDigits:2];
     
     NSString *stringMaybeChanged = [NSString stringWithString:string];
     if (stringMaybeChanged.length > 1)


### PR DESCRIPTION
Except the title I mentioned, I swap `int` type to `NSInteger` regarding to 64-bit architecture in iOS 7
